### PR TITLE
Add project explorer and document register features

### DIFF
--- a/EDMS.html
+++ b/EDMS.html
@@ -11,15 +11,20 @@
   <script src="https://cdn.jsdelivr.net/npm/js-treeview@1.0.2/treeview.min.js"></script>
 </head>
 <body class="bg-gray-100 text-gray-800 p-6 font-sans">
+  <div class="mb-4 space-x-2">
+    <button id="toggleExplorer" class="px-2 py-1 border rounded">Toggle Explorer</button>
+    <button id="toggleRegister" class="px-2 py-1 border rounded">Toggle Register</button>
+    <button id="toggleDetails" class="px-2 py-1 border rounded">Toggle Details</button>
+  </div>
   <div class="grid grid-cols-4 gap-4">
-    <div class="col-span-1 bg-white p-4 rounded shadow">
+    <div class="col-span-1 bg-white p-4 rounded shadow explorer">
       <h2 class="text-lg font-semibold mb-4">Project Explorer</h2>
       <div id="treeview"></div>
       <button onclick="addProject()" class="mt-4 w-full bg-blue-600 text-white py-2 rounded">+ Add Project</button>
     </div>
 
-    <div class="col-span-3 space-y-4">
-      <div class="bg-white p-4 rounded shadow">
+    <div class="col-span-3 space-y-4 register">
+      <div class="bg-white p-4 rounded shadow register-section">
         <div class="flex justify-between items-center mb-2">
           <h2 class="text-lg font-semibold">Document Register</h2>
           <button onclick="openDocModal()" class="bg-green-600 text-white px-4 py-2 rounded">+ Add Document</button>
@@ -32,7 +37,7 @@
         </table>
       </div>
 
-      <div class="bg-white p-4 rounded shadow">
+      <div class="bg-white p-4 rounded shadow details">
         <h3 class="text-md font-semibold mb-2">Related Document Details</h3>
         <div id="docDetails" class="text-sm text-gray-600 italic">Select a document to view details.</div>
       </div>
@@ -55,19 +60,77 @@
   </div>
 
   <script>
-    const projects = [{text: "2200 - Leach Project", nodes: ["2200-01 - Assembly", "2200-02 - Docs"]}];
-    const documents = [
-      {project: "2200-01 - Assembly", title: "Heater Diagram", code: "2210-XD1", version: "Rev 1"}
+    const projects = [
+      {
+        text: "2200 - Leach Project",
+        nodes: [
+          { text: "2200-01 - Assembly" },
+          { text: "2200-02 - Docs" }
+        ]
+      },
+      {
+        text: "2300 - Mining Project",
+        nodes: [
+          { text: "2300-01 - Plans" },
+          { text: "2300-02 - Reports" }
+        ]
+      }
     ];
+
+    const projectDetails = {
+      "2200 - Leach Project": "Main project for Leach operations.",
+      "2200-01 - Assembly": "Assembly operations.",
+      "2200-02 - Docs": "Documentation tasks.",
+      "2300 - Mining Project": "Mining project overview.",
+      "2300-01 - Plans": "Planning documents.",
+      "2300-02 - Reports": "Reporting documents."
+    };
+
+    const documents = [
+      {project: "2200-01 - Assembly", title: "Heater Diagram", code: "2210-XD1", version: "Rev 1"},
+      {project: "2200-02 - Docs", title: "Spec Sheet", code: "2200-SP", version: "A"},
+      {project: "2300-01 - Plans", title: "Mine Layout", code: "2300-ML", version: "0"}
+    ];
+
+    const STORAGE_KEY = 'edmsDocs';
+
+    function loadDocs() {
+      const saved = localStorage.getItem(STORAGE_KEY);
+      if (saved) {
+        documents.length = 0;
+        documents.push(...JSON.parse(saved));
+      }
+    }
+
+    function saveDocs() {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(documents));
+    }
+
+    function getDocsForNode(node) {
+      const names = [];
+      (function traverse(n){
+        names.push(n.text);
+        if (n.nodes) n.nodes.forEach(traverse);
+      })(node);
+      return documents.filter(d => names.includes(d.project));
+    }
+
+    function showDocDetails(doc) {
+      $("#docDetails").html(
+        `<div><strong>Project:</strong> ${doc.project}</div>`+
+        `<div><strong>Title:</strong> ${doc.title}</div>`+
+        `<div><strong>Code:</strong> ${doc.code}</div>`+
+        `<div><strong>Version:</strong> ${doc.version}</div>`
+      );
+    }
 
     function renderTree() {
       new TreeView(document.getElementById("treeview"), {
         data: projects,
         onNodeClick: function(node) {
-          const proj = node.text;
-          const filtered = documents.filter(d => d.project === proj);
-          renderDocs(filtered);
-          $("#docDetails").html(`<strong>Selected:</strong> ${proj}`);
+          const docs = getDocsForNode(node);
+          renderDocs(docs);
+          $("#docDetails").html(`<strong>Selected Project:</strong> ${node.text}<br><em>${projectDetails[node.text] || ''}</em>`);
         }
       });
     }
@@ -75,13 +138,15 @@
     function renderDocs(docs = documents) {
       const tbody = $("#docTableBody").empty();
       docs.forEach((d, i) => {
-        tbody.append(`<tr>
-          <td class="border px-2 py-1">${d.project}</td>
-          <td class="border px-2 py-1">${d.title}</td>
-          <td class="border px-2 py-1">${d.code}</td>
-          <td class="border px-2 py-1">${d.version}</td>
-          <td class="border px-2 py-1"><button onclick="editDoc(${i})" class="text-blue-600">Edit</button> | <button onclick="deleteDoc(${i})" class="text-red-600">Delete</button></td>
-        </tr>`);
+        const row = $(`<tr data-index="${i}" class="cursor-pointer hover:bg-gray-50">
+            <td class="border px-2 py-1">${d.project}</td>
+            <td class="border px-2 py-1">${d.title}</td>
+            <td class="border px-2 py-1">${d.code}</td>
+            <td class="border px-2 py-1">${d.version}</td>
+            <td class="border px-2 py-1"><button onclick="editDoc(${i})" class="text-blue-600">Edit</button> | <button onclick="deleteDoc(${i})" class="text-red-600">Delete</button></td>
+          </tr>`);
+        row.click(() => showDocDetails(d));
+        tbody.append(row);
       });
     }
 
@@ -106,7 +171,9 @@
       if (idx === "") documents.push(doc);
       else documents[idx] = doc;
       closeModal();
+      saveDocs();
       renderDocs();
+      showDocDetails(doc);
     });
 
     function editDoc(i) {
@@ -123,7 +190,9 @@
     function deleteDoc(i) {
       if (confirm("Are you sure?")) {
         documents.splice(i, 1);
+        saveDocs();
         renderDocs();
+        $("#docDetails").html("Select a document to view details.");
       }
     }
 
@@ -136,8 +205,13 @@
     }
 
     $(document).ready(() => {
+      loadDocs();
       renderTree();
       renderDocs();
+
+      $("#toggleExplorer").click(() => $(".explorer").toggleClass("hidden"));
+      $("#toggleRegister").click(() => $(".register-section").toggleClass("hidden"));
+      $("#toggleDetails").click(() => $(".details").toggleClass("hidden"));
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- add section toggle buttons
- convert project data to tree structure and add sample projects
- show project and document details on selection
- persist documents using localStorage
- improve CRUD operations and include row click handlers

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68492ba69e488328bda847e4efe7fb8d