### PR TITLE
Integrate Playwright

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 package-lock.json
+test-results/

--- a/README.md
+++ b/README.md
@@ -3,3 +3,17 @@
 This example shows a simple document management interface with a tree view of projects and a small CRUD table. All dependencies are included locally so the page can be opened without an internet connection.
 
 Open `EDMS.html` in a browser to try it out.
+
+## Running tests
+
+Unit tests use Jest:
+
+```
+npm test
+```
+
+End-to-end tests use Playwright:
+
+```
+npm run test:e2e
+```

--- a/e2e/edms.spec.js
+++ b/e2e/edms.spec.js
@@ -1,0 +1,16 @@
+const { test, expect } = require('@playwright/test');
+const path = require('path');
+
+const filePath = 'file://' + path.resolve(__dirname, '../EDMS.html');
+
+test('loads page title', async ({ page }) => {
+  await page.goto(filePath);
+  await expect(page).toHaveTitle(/EDMS/);
+});
+
+test('toggle explorer hides explorer section', async ({ page }) => {
+  await page.goto(filePath);
+  await page.click('#toggleExplorer');
+  const className = await page.locator('.explorer').getAttribute('class');
+  expect(className).toMatch(/hidden/);
+});

--- a/package.json
+++ b/package.json
@@ -4,15 +4,23 @@
   "description": "This example shows a simple document management interface with a tree view of projects and a small CRUD table. All dependencies are included locally so the page can be opened without an internet connection.",
   "main": "treeview.js",
   "scripts": {
-    "test": "jest"
+    "test": "jest",
+    "test:e2e": "playwright test"
+  },
+  "jest": {
+    "testMatch": [
+      "**/__tests__/**/*.test.js"
+    ]
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
+    "@playwright/test": "^1.53.0",
     "jest": "^30.0.0",
-    "jsdom": "^26.1.0"
+    "jsdom": "^26.1.0",
+    "playwright": "^1.53.0"
   },
   "dependencies": {
     "jquery": "^3.7.1"

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,4 @@
+const path = require('path');
+module.exports = {
+  testDir: 'e2e',
+};


### PR DESCRIPTION
## Summary
- add Playwright test runner setup
- create end-to-end test for EDMS.html
- document how to run Jest and Playwright
- ignore Playwright result artifacts

## Testing
- `npm test`
- `npm run test:e2e`

------
https://chatgpt.com/codex/tasks/task_e_684935c1d84c8328bb1b21687f49f0b1