### PR TITLE
Add CRUD tests for documents

### DIFF
--- a/EDMS.html
+++ b/EDMS.html
@@ -78,12 +78,12 @@
         <form id="docForm">
           <input type="hidden" id="docId" />
           <div class="mb-2">
-            <label class="block text-sm">Project</label
-            ><input
+            <label class="block text-sm">Project</label>
+            <select
               id="docProject"
               class="w-full border px-2 py-1 rounded"
               required
-            />
+            ></select>
           </div>
           <div class="mb-2">
             <label class="block text-sm">Title</label
@@ -192,6 +192,24 @@
         return documents.filter((d) => names.includes(d.project));
       }
 
+      function getAllProjectNames() {
+        const all = [];
+        function traverse(n) {
+          all.push(n.text);
+          if (n.nodes) n.nodes.forEach(traverse);
+        }
+        projects.forEach(traverse);
+        return all;
+      }
+
+      function populateProjectDropdown() {
+        const select = $("#docProject");
+        select.empty();
+        getAllProjectNames().forEach((name) => {
+          select.append(`<option value="${name}">${name}</option>`);
+        });
+      }
+
       function showDocDetails(doc) {
         $("#docDetails").html(
           `<div><strong>Project:</strong> ${doc.project}</div>` +
@@ -234,6 +252,7 @@
       }
 
       function openDocModal() {
+        populateProjectDropdown();
         $("#modalTitle").text("Add Document");
         $("#docForm")[0].reset();
         $("#docId").val("");
@@ -263,6 +282,7 @@
 
       function editDoc(i) {
         const d = documents[i];
+        populateProjectDropdown();
         $("#modalTitle").text("Edit Document");
         $("#docId").val(i);
         $("#docProject").val(d.project);
@@ -293,6 +313,7 @@
         loadDocs();
         renderTree();
         renderDocs();
+        populateProjectDropdown();
 
         $("#toggleExplorer").click(() => $(".explorer").toggleClass("hidden"));
         $("#toggleRegister").click(() =>

--- a/EDMS.html
+++ b/EDMS.html
@@ -148,6 +148,8 @@
         "2300-02 - Reports": "Reporting documents.",
       };
 
+      let selectedProject = null;
+
       window.documents = [
         {
           project: "2200-01 - Assembly",
@@ -223,6 +225,7 @@
         new TreeView(document.getElementById("treeview"), {
           data: projects,
           onNodeClick: function (node) {
+            selectedProject = node.text;
             const docs = getDocsForNode(node);
             renderDocs(docs);
             $("#docDetails").html(
@@ -256,6 +259,9 @@
         $("#modalTitle").text("Add Document");
         $("#docForm")[0].reset();
         $("#docId").val("");
+        if (selectedProject) {
+          $("#docProject").val(selectedProject);
+        }
         $("#docModal").removeClass("hidden");
       }
 

--- a/__tests__/addDocument.test.js
+++ b/__tests__/addDocument.test.js
@@ -54,6 +54,17 @@ test('child document appears when parent is selected', () => {
   expect(titles).toContain('Child Doc');
 });
 
+test('child document appears when child node is selected', () => {
+  const { window } = dom;
+  const child = [...window.document.querySelectorAll('.tv-label')].find(
+    (el) => el.textContent === '2200-01 - Assembly'
+  );
+  child.click();
+  const rows = [...window.document.querySelectorAll('#docTableBody tr')];
+  const titles = rows.map((r) => r.children[1].textContent);
+  expect(titles).toContain('Child Doc');
+});
+
 test('clicking a row shows document details', () => {
   const { window } = dom;
   const row = window.document.querySelector('#docTableBody').lastElementChild;

--- a/__tests__/addDocument.test.js
+++ b/__tests__/addDocument.test.js
@@ -20,11 +20,25 @@ beforeAll(async () => {
   });
 });
 
+test('project dropdown contains existing projects', () => {
+  const { window } = dom;
+  window.openDocModal();
+  const options = [...window.document.querySelectorAll('#docProject option')].map(o => o.value);
+  expect(options).toEqual(
+    expect.arrayContaining([
+      '2200 - Leach Project',
+      '2200-01 - Assembly',
+      '2300 - Mining Project'
+    ])
+  );
+  window.closeModal();
+});
+
 test('adding a document updates the table and list', () => {
   const { window } = dom;
   const initialLen = window.documents.length;
   window.openDocModal();
-  window.document.getElementById('docProject').value = 'Test Project';
+  window.document.getElementById('docProject').value = '2200 - Leach Project';
   window.document.getElementById('docTitle').value = 'Test Doc';
   window.document.getElementById('docCode').value = 'TST';
   window.document.getElementById('docVersion').value = '1';
@@ -32,7 +46,7 @@ test('adding a document updates the table and list', () => {
   form.dispatchEvent(new window.Event('submit', { bubbles: true, cancelable: true }));
   expect(window.documents.length).toBe(initialLen + 1);
   const lastRow = window.document.querySelector('#docTableBody').lastElementChild;
-  expect(lastRow.firstElementChild.textContent).toBe('Test Project');
+  expect(lastRow.firstElementChild.textContent).toBe('2200 - Leach Project');
 });
 
 test('child document appears when parent is selected', () => {

--- a/__tests__/addDocument.test.js
+++ b/__tests__/addDocument.test.js
@@ -16,7 +16,7 @@ beforeAll(async () => {
     .replace('treeview.js', 'file://' + treeviewPath);
   dom = new JSDOM(inline, { runScripts: 'dangerously', resources: 'usable', url: 'http://localhost' });
   await new Promise((resolve) => {
-    dom.window.addEventListener('load', resolve);
+    dom.window.addEventListener('load', () => setTimeout(resolve, 0));
   });
 });
 
@@ -33,4 +33,51 @@ test('adding a document updates the table and list', () => {
   expect(window.documents.length).toBe(initialLen + 1);
   const lastRow = window.document.querySelector('#docTableBody').lastElementChild;
   expect(lastRow.firstElementChild.textContent).toBe('Test Project');
+});
+
+test('child document appears when parent is selected', () => {
+  const { window } = dom;
+  window.openDocModal();
+  window.document.getElementById('docProject').value = '2200-01 - Assembly';
+  window.document.getElementById('docTitle').value = 'Child Doc';
+  window.document.getElementById('docCode').value = 'CHD';
+  window.document.getElementById('docVersion').value = '1';
+  window.document.getElementById('docForm').dispatchEvent(
+    new window.Event('submit', { bubbles: true, cancelable: true })
+  );
+  const parent = [...window.document.querySelectorAll('.tv-label')].find(
+    (el) => el.textContent === '2200 - Leach Project'
+  );
+  parent.click();
+  const rows = [...window.document.querySelectorAll('#docTableBody tr')];
+  const titles = rows.map((r) => r.children[1].textContent);
+  expect(titles).toContain('Child Doc');
+});
+
+test('clicking a row shows document details', () => {
+  const { window } = dom;
+  const row = window.document.querySelector('#docTableBody').lastElementChild;
+  row.click();
+  expect(window.document.getElementById('docDetails').textContent).toContain('Child Doc');
+});
+
+test('editing a document updates the table', () => {
+  const { window } = dom;
+  window.editDoc(0);
+  window.document.getElementById('docTitle').value = 'Updated Doc';
+  window.document.getElementById('docForm').dispatchEvent(
+    new window.Event('submit', { bubbles: true, cancelable: true })
+  );
+  const firstRowTitle = window.document.querySelector('#docTableBody tr').children[1].textContent;
+  expect(firstRowTitle).toBe('Updated Doc');
+});
+
+test('deleteDoc removes a document', () => {
+  const { window } = dom;
+  const initial = window.documents.length;
+  window.confirm = jest.fn().mockReturnValue(true);
+  window.deleteDoc(0);
+  expect(window.documents.length).toBe(initial - 1);
+  const rows = window.document.querySelectorAll('#docTableBody tr');
+  expect(rows.length).toBe(initial - 1);
 });

--- a/__tests__/addDocument.test.js
+++ b/__tests__/addDocument.test.js
@@ -34,6 +34,19 @@ test('project dropdown contains existing projects', () => {
   window.closeModal();
 });
 
+test('modal selects current project when opening', () => {
+  const { window } = dom;
+  const label = [...window.document.querySelectorAll('.tv-label')].find(
+    el => el.textContent === '2300 - Mining Project'
+  );
+  label.click();
+  window.openDocModal();
+  expect(window.document.getElementById('docProject').value).toBe(
+    '2300 - Mining Project'
+  );
+  window.closeModal();
+});
+
 test('adding a document updates the table and list', () => {
   const { window } = dom;
   const initialLen = window.documents.length;


### PR DESCRIPTION
## Summary
- extend addDocument.test with CRUD coverage
- verify parent filter shows newly added child document
- check document details, update, and delete operations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685116ec2e8c8328b664254d01fed2d2