### PR TITLE
Fix tree refresh when adding items

### DIFF
--- a/EDMS.html
+++ b/EDMS.html
@@ -222,7 +222,7 @@
       }
 
       function renderTree() {
-        new TreeView(document.getElementById("treeview"), {
+        const tree = new TreeView(document.getElementById("treeview"), {
           data: projects,
           onNodeClick: function (node) {
             selectedProject = node.text;
@@ -235,6 +235,12 @@
             );
           },
         });
+        if (selectedProject) {
+          const label = [...document.querySelectorAll('#treeview .tv-label')].find(
+            (el) => el.textContent === selectedProject
+          );
+          if (label) label.click();
+        }
       }
 
       function renderDocs(docs = documents) {
@@ -284,6 +290,8 @@
         saveDocs();
         renderDocs();
         showDocDetails(doc);
+        selectedProject = doc.project;
+        renderTree();
       });
 
       function editDoc(i) {
@@ -304,6 +312,8 @@
           saveDocs();
           renderDocs();
           $("#docDetails").html("Select a document to view details.");
+          selectedProject = null;
+          renderTree();
         }
       }
 
@@ -311,6 +321,7 @@
         const newProj = prompt("Enter project name:");
         if (newProj) {
           projects.push({ text: newProj });
+          selectedProject = newProj;
           renderTree();
         }
       }

--- a/__tests__/addDocument.test.js
+++ b/__tests__/addDocument.test.js
@@ -62,6 +62,24 @@ test('adding a document updates the table and list', () => {
   expect(lastRow.firstElementChild.textContent).toBe('2200 - Leach Project');
 });
 
+test('selection persists after adding a document', () => {
+  const { window } = dom;
+  const label = [...window.document.querySelectorAll('.tv-label')].find(
+    (el) => el.textContent === '2200 - Leach Project'
+  );
+  label.click();
+  window.openDocModal();
+  window.document.getElementById('docProject').value = '2200 - Leach Project';
+  window.document.getElementById('docTitle').value = 'Persist';
+  window.document.getElementById('docCode').value = 'PRS';
+  window.document.getElementById('docVersion').value = '1';
+  window.document.getElementById('docForm').dispatchEvent(
+    new window.Event('submit', { bubbles: true, cancelable: true })
+  );
+  const selected = window.document.querySelector('.tv-label.selected');
+  expect(selected.textContent).toBe('2200 - Leach Project');
+});
+
 test('child document appears when parent is selected', () => {
   const { window } = dom;
   window.openDocModal();

--- a/__tests__/treeview.test.js
+++ b/__tests__/treeview.test.js
@@ -44,6 +44,13 @@ test('addProject adds a new root node', () => {
   expect(after).toBe(before + 1);
 });
 
+test('newly added project is selected', () => {
+  dom.window.prompt = jest.fn().mockReturnValue('Selected Project');
+  dom.window.addProject();
+  const selected = dom.window.document.querySelector('.tv-label.selected');
+  expect(selected.textContent).toBe('Selected Project');
+});
+
 test('node click selects the node', () => {
   const label = dom.window.document.querySelector('.tv-label');
   label.click();


### PR DESCRIPTION
## Summary
- keep selection when rerendering tree
- reselect after adding project or document
- restore unfiltered view on delete
- test UI tree updates on project and document changes

## Testing
- `npm test`
- `npm run test:e2e` *(fails: browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68511bec79588328be4a743cd2b2e27a