### PR TITLE
Fix tree refresh when adding items

### DIFF
--- a/EDMS.html
+++ b/EDMS.html
@@ -204,6 +204,30 @@
         return all;
       }
 
+      function findProject(name, nodes = projects) {
+        for (const node of nodes) {
+          if (node.text === name) return node;
+          if (node.nodes) {
+            const found = findProject(name, node.nodes);
+            if (found) return found;
+          }
+        }
+        return null;
+      }
+
+      function ensureProjectNode(name) {
+        if (findProject(name)) return;
+        for (const root of projects) {
+          const code = root.text.split(" ")[0];
+          if (name.startsWith(code) && name !== root.text) {
+            root.nodes = root.nodes || [];
+            root.nodes.push({ text: name });
+            return;
+          }
+        }
+        projects.push({ text: name });
+      }
+
       function populateProjectDropdown() {
         const select = $("#docProject");
         select.empty();
@@ -222,7 +246,7 @@
       }
 
       function renderTree() {
-        new TreeView(document.getElementById("treeview"), {
+        const tree = new TreeView(document.getElementById("treeview"), {
           data: projects,
           onNodeClick: function (node) {
             selectedProject = node.text;
@@ -235,6 +259,12 @@
             );
           },
         });
+        if (selectedProject) {
+          const label = [...document.querySelectorAll('#treeview .tv-label')].find(
+            (el) => el.textContent === selectedProject
+          );
+          if (label) label.click();
+        }
       }
 
       function renderDocs(docs = documents) {
@@ -280,10 +310,15 @@
         };
         if (idx === "") documents.push(doc);
         else documents[idx] = doc;
+
+        ensureProjectNode(doc.project);
+
         closeModal();
         saveDocs();
         renderDocs();
         showDocDetails(doc);
+        selectedProject = doc.project;
+        renderTree();
       });
 
       function editDoc(i) {
@@ -304,6 +339,8 @@
           saveDocs();
           renderDocs();
           $("#docDetails").html("Select a document to view details.");
+          selectedProject = null;
+          renderTree();
         }
       }
 
@@ -311,7 +348,9 @@
         const newProj = prompt("Enter project name:");
         if (newProj) {
           projects.push({ text: newProj });
+          selectedProject = newProj;
           renderTree();
+          populateProjectDropdown();
         }
       }
 

--- a/__tests__/addDocument.test.js
+++ b/__tests__/addDocument.test.js
@@ -62,6 +62,71 @@ test('adding a document updates the table and list', () => {
   expect(lastRow.firstElementChild.textContent).toBe('2200 - Leach Project');
 });
 
+test('selection persists after adding a document', () => {
+  const { window } = dom;
+  const label = [...window.document.querySelectorAll('.tv-label')].find(
+    (el) => el.textContent === '2200 - Leach Project'
+  );
+  label.click();
+  window.openDocModal();
+  window.document.getElementById('docProject').value = '2200 - Leach Project';
+  window.document.getElementById('docTitle').value = 'Persist';
+  window.document.getElementById('docCode').value = 'PRS';
+  window.document.getElementById('docVersion').value = '1';
+  window.document.getElementById('docForm').dispatchEvent(
+    new window.Event('submit', { bubbles: true, cancelable: true })
+  );
+  const selected = window.document.querySelector('.tv-label.selected');
+  expect(selected.textContent).toBe('2200 - Leach Project');
+});
+
+test('adding a document for a new project adds a tree node', () => {
+  const { window } = dom;
+  window.openDocModal();
+  const newProj = '2400 - New Node';
+  const select = window.document.getElementById('docProject');
+  const opt = window.document.createElement('option');
+  opt.value = newProj;
+  opt.textContent = newProj;
+  select.appendChild(opt);
+  select.value = newProj;
+  window.document.getElementById('docTitle').value = 'Doc';
+  window.document.getElementById('docCode').value = 'DOC';
+  window.document.getElementById('docVersion').value = '1';
+  window.document.getElementById('docForm').dispatchEvent(
+    new window.Event('submit', { bubbles: true, cancelable: true })
+  );
+  const labels = [...window.document.querySelectorAll('.tv-label')].map(
+    (el) => el.textContent
+  );
+  expect(labels).toContain(newProj);
+});
+
+test('adding a document for a new subproject adds child node', () => {
+  const { window } = dom;
+  window.openDocModal();
+  const newChild = '2200-03 - Extra';
+  const select = window.document.getElementById('docProject');
+  const opt = window.document.createElement('option');
+  opt.value = newChild;
+  opt.textContent = newChild;
+  select.appendChild(opt);
+  select.value = newChild;
+  window.document.getElementById('docTitle').value = 'Doc';
+  window.document.getElementById('docCode').value = 'DOC';
+  window.document.getElementById('docVersion').value = '1';
+  window.document.getElementById('docForm').dispatchEvent(
+    new window.Event('submit', { bubbles: true, cancelable: true })
+  );
+  const rootLi = [...window.document.querySelectorAll('.tv-item[data-level="0"]')].find(
+    (li) => li.querySelector('.tv-label').textContent === '2200 - Leach Project'
+  );
+  const children = [
+    ...rootLi.querySelectorAll('.tv-item[data-level="1"] > .tv-label')
+  ].map((el) => el.textContent);
+  expect(children).toContain(newChild);
+});
+
 test('child document appears when parent is selected', () => {
   const { window } = dom;
   window.openDocModal();

--- a/__tests__/treeview.test.js
+++ b/__tests__/treeview.test.js
@@ -44,6 +44,22 @@ test('addProject adds a new root node', () => {
   expect(after).toBe(before + 1);
 });
 
+test('newly added project is selected', () => {
+  dom.window.prompt = jest.fn().mockReturnValue('Selected Project');
+  dom.window.addProject();
+  const selected = dom.window.document.querySelector('.tv-label.selected');
+  expect(selected.textContent).toBe('Selected Project');
+});
+
+test('addProject updates dropdown', () => {
+  dom.window.prompt = jest.fn().mockReturnValue('Dropdown Project');
+  dom.window.addProject();
+  dom.window.openDocModal();
+  const options = [...dom.window.document.querySelectorAll('#docProject option')].map(o => o.value);
+  expect(options).toContain('Dropdown Project');
+  dom.window.closeModal();
+});
+
 test('node click selects the node', () => {
   const label = dom.window.document.querySelector('.tv-label');
   label.click();


### PR DESCRIPTION
## Summary
- keep selection when rerendering tree
- reselect after adding project or document
- restore unfiltered view on delete
- update tree when new doc adds a new project or subproject
- update dropdown when adding a project
- test UI tree updates on project and document changes

## Testing
- `npm test`
- `npm run test:e2e` *(fails: browsers not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68511bec79588328be4a743cd2b2e27a