### PR TITLE
Fix tree rebuild on stored documents

### DIFF
--- a/EDMS.html
+++ b/EDMS.html
@@ -178,6 +178,7 @@
         if (saved) {
           documents.length = 0;
           documents.push(...JSON.parse(saved));
+          ensureProjectsFromDocs();
         }
       }
 
@@ -213,6 +214,14 @@
           }
         }
         return null;
+      }
+
+      function ensureProjectsFromDocs() {
+        documents.forEach(doc => {
+          if (!findProject(doc.project)) {
+            projects.push({ text: doc.project });
+          }
+        });
       }
 
       function populateProjectDropdown() {

--- a/__tests__/addDocument.test.js
+++ b/__tests__/addDocument.test.js
@@ -159,3 +159,45 @@ test('deleteDoc removes a document', () => {
   const rows = window.document.querySelectorAll('#docTableBody tr');
   expect(rows.length).toBe(initial - 1);
 });
+
+test('tree shows stored projects on reload', async () => {
+  const { window } = dom;
+  window.openDocModal();
+  const newProj = '3000 - Persisted';
+  const select = window.document.getElementById('docProject');
+  const opt = window.document.createElement('option');
+  opt.value = newProj;
+  opt.textContent = newProj;
+  select.appendChild(opt);
+  select.value = newProj;
+  window.document.getElementById('docTitle').value = 'Persist';
+  window.document.getElementById('docCode').value = 'PST';
+  window.document.getElementById('docVersion').value = '1';
+  window.document.getElementById('docForm').dispatchEvent(
+    new window.Event('submit', { bubbles: true, cancelable: true })
+  );
+  const stored = window.localStorage.getItem('edmsDocs');
+
+  const html = fs.readFileSync(path.join(__dirname, '..', 'EDMS.html'), 'utf-8');
+  const jqueryPath = path.resolve(require.resolve('jquery/dist/jquery.min.js'));
+  const treeviewPath = path.resolve(path.join(__dirname, '..', 'treeview.js'));
+  const inline = html
+    .replace('<script src="tailwindstub.js"></script>', '')
+    .replace('<link rel="stylesheet" href="tailwind.css"/>', '')
+    .replace('<link rel="stylesheet" href="treeview.css"/>', '')
+    .replace('jquery.min.js', 'file://' + jqueryPath)
+    .replace('treeview.js', 'file://' + treeviewPath);
+  const dom2 = new JSDOM(inline, {
+    runScripts: 'dangerously',
+    resources: 'usable',
+    url: 'http://localhost',
+    beforeParse(win) {
+      win.localStorage.setItem('edmsDocs', stored);
+    },
+  });
+  await new Promise((resolve) => {
+    dom2.window.addEventListener('load', () => setTimeout(resolve, 0));
+  });
+  const labels = [...dom2.window.document.querySelectorAll('.tv-label')].map((l) => l.textContent);
+  expect(labels).toContain(newProj);
+});


### PR DESCRIPTION
## Summary
- ensure stored documents generate project nodes on load
- test project nodes persisted across reloads

## Testing
- `npm test`
- `npm run test:e2e` *(fails: browser not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68512295c76483289814d0558755a6f1