### PR TITLE
Fix tree rebuild on stored documents

### DIFF
--- a/EDMS.html
+++ b/EDMS.html
@@ -178,6 +178,7 @@
         if (saved) {
           documents.length = 0;
           documents.push(...JSON.parse(saved));
+          ensureProjectsFromDocs();
         }
       }
 
@@ -215,6 +216,26 @@
         return null;
       }
 
+      function addProjectNode(name) {
+        if (findProject(name)) return;
+        const childMatch = name.match(/^(\d{4})-/);
+        if (childMatch) {
+          const root = projects.find(p => p.text.startsWith(childMatch[1] + ' '));
+          if (root) {
+            root.nodes = root.nodes || [];
+            root.nodes.push({ text: name });
+            return;
+          }
+        }
+        projects.push({ text: name });
+      }
+
+      function ensureProjectsFromDocs() {
+        documents.forEach(doc => {
+          addProjectNode(doc.project);
+        });
+      }
+
       function populateProjectDropdown() {
         const select = $("#docProject");
         select.empty();
@@ -250,7 +271,14 @@
           const label = [...document.querySelectorAll('#treeview .tv-label')].find(
             (el) => el.textContent === selectedProject
           );
-          if (label) label.click();
+          if (label) {
+            let p = label.parentElement;
+            while (p && p.id !== 'treeview') {
+              if (p.tagName === 'LI') p.classList.remove('tv-collapsed');
+              p = p.parentElement;
+            }
+            label.click();
+          }
         }
       }
 
@@ -298,9 +326,7 @@
         if (idx === "") documents.push(doc);
         else documents[idx] = doc;
 
-        if (!findProject(doc.project)) {
-          projects.push({ text: doc.project });
-        }
+        addProjectNode(doc.project);
 
         closeModal();
         saveDocs();

--- a/EDMS.html
+++ b/EDMS.html
@@ -362,7 +362,7 @@
       function addProject() {
         const newProj = prompt("Enter project name:");
         if (newProj) {
-          projects.push({ text: newProj });
+          addProjectNode(newProj);
           selectedProject = newProj;
           renderTree();
         }

--- a/__tests__/treeview.test.js
+++ b/__tests__/treeview.test.js
@@ -51,6 +51,14 @@ test('newly added project is selected', () => {
   expect(selected.textContent).toBe('Selected Project');
 });
 
+test('addProject nests child names under the correct root', () => {
+  dom.window.prompt = jest.fn().mockReturnValue('2200-04 - Extra Child');
+  dom.window.addProject();
+  const root = dom.window.findProject('2200 - Leach Project');
+  const childNames = root.nodes.map(n => n.text);
+  expect(childNames).toContain('2200-04 - Extra Child');
+});
+
 test('node click selects the node', () => {
   const label = dom.window.document.querySelector('.tv-label');
   label.click();


### PR DESCRIPTION
## Summary
- ensure stored documents generate project nodes on load
- test project nodes persisted across reloads
- properly nest new projects using addProjectNode
- expand ancestors when tree re-renders
- add regression test for nested project addition

## Testing
- `npm test`
- `npm run test:e2e` *(fails: browser not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68512295c76483289814d0558755a6f1